### PR TITLE
fix: suppress spurious 'Done' notifications while waiting for user input

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,14 @@ const plugin: Plugin = async ({ client, $ }) => {
     return trimmed === "" ? undefined : trimmed
   }
 
+  function getQuestionRequestID(source: any): string | undefined {
+    if (!source) return undefined
+    const rawID = source.id ?? source.requestID
+    if (typeof rawID !== "string") return undefined
+    const trimmed = rawID.trim()
+    return trimmed === "" ? undefined : trimmed
+  }
+
   async function fetchSession(
     sessionID: string,
   ): Promise<{ title: string; parentID?: string } | null> {
@@ -57,7 +65,7 @@ const plugin: Plugin = async ({ client, $ }) => {
         if (status.type === "idle") {
           // If we're waiting for user input (permission prompt or question),
           // the session goes idle because the model is not generating — but
-          // we are NOT done.  Keep the current sidebar status and skip the
+          // we are NOT done. Keep the current sidebar status and skip the
           // "Done" notification.
           if (isWaitingForInput()) {
             return
@@ -141,8 +149,10 @@ const plugin: Plugin = async ({ client, $ }) => {
 
       // Handle question events
       if (e.type === "question.asked") {
-        const id = e.properties.id
-        pendingQuestions.add(id)
+        const id = getQuestionRequestID(e.properties)
+        if (id) {
+          pendingQuestions.add(id)
+        }
 
         const header = e.properties.questions?.[0]?.header ?? "Question"
         await setStatus($, "opencode", "question", {
@@ -155,8 +165,10 @@ const plugin: Plugin = async ({ client, $ }) => {
       }
 
       if (e.type === "question.replied" || e.type === "question.rejected") {
-        const id = e.properties.requestID
-        pendingQuestions.delete(id)
+        const id = getQuestionRequestID(e.properties)
+        if (id) {
+          pendingQuestions.delete(id)
+        }
 
         if (!isWaitingForInput()) {
           await setStatus($, "opencode", "working", {
@@ -170,7 +182,7 @@ const plugin: Plugin = async ({ client, $ }) => {
 
     async "permission.ask"(input) {
       // The hook fires synchronously in the permission pipeline, before the
-      // event.  Record it eagerly so the idle-suppression logic is already
+      // event. Record it eagerly so the idle-suppression logic is already
       // active when session.status arrives.
       const id = getPermissionRequestID(input as any)
       if (id) {
@@ -180,7 +192,7 @@ const plugin: Plugin = async ({ client, $ }) => {
       const title = (input as any).title ?? (input as any).permission ?? "command"
       await setStatus($, "opencode", "waiting", {
         icon: "lock",
-        color "#ef4444",
+        color: "#ef4444",
       })
       await notify($, { title: "Needs your permission", subtitle: title })
       await log($, `Permission requested: ${title}`, {


### PR DESCRIPTION
## Summary

When OpenCode prompts for permission or asks the user a question, the session status transitions to `idle` (the model is not generating). The current code treats **every** `idle` event as task-completion — firing a "Done" notification and clearing the sidebar status — even though the session is actually waiting for user input.

This PR fixes the issue by tracking pending permission and question requests, and suppressing the idle → "Done" path while any user input is outstanding.

## What changed

- **Pending-input tracking**: two `Set<string>`s (`pendingPermissions`, `pendingQuestions`) track in-flight permission and question request IDs.
- **`session.status: idle` suppression**: when there is pending input, skip the "Done" notification and sidebar clear.
- **`session.status: busy` guard**: don't overwrite a more-specific "waiting" / "question" sidebar status with generic "working".
- **Permission event handlers**: handle `permission.asked` / `permission.updated` / `permission.replied` events (belt-and-suspenders with the `permission.ask` hook).
- **Question lifecycle**: `question.asked` adds to pending set; `question.replied` / `question.rejected` removes. After clearing, restore "working" status instead of clearing entirely.
- **Error cleanup**: `session.error` clears both pending sets as a safety valve.
- **`permission.ask` hook**: eagerly records the pending permission ID before the event fires, so idle-suppression is already active.

## Disclosure

This PR was written with LLM assistance (Claude). The fix was validated locally — it correctly sends notifications when waiting for input and suppresses the spurious "Done" notification that previously fired on every permission/question prompt.