### PR TITLE
fix(cmux): notifications under SSH+tmux + per-event config

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ OpenCode plugin that bridges OpenCode events to cmux notifications and sidebar m
 ## Requirements
 
 - OpenCode ≥ 1.0
-- [cmux](https://cmux.app) (macOS app) installed with CLI accessible at `/usr/local/bin/cmux`
+- [cmux](https://cmux.app) (macOS app) installed; the plugin invokes `cmux` via `$CMUX_BUNDLED_CLI_PATH` (set by cmux's shell integration), falling back to `cmux` on `$PATH`
 - The plugin is a no-op when not running inside a cmux workspace
 
 ## Installation
@@ -38,15 +38,22 @@ Create `~/.config/opencode/opencode-cmux.json` to customize plugin behavior:
 
 ```json
 {
-  "splits": true
+  "splits": true,
+  "notifications": {
+    "done": false
+  }
 }
 ```
 
-| Option   | Type    | Default | Description                                              |
-|----------|---------|---------|----------------------------------------------------------|
-| `splits` | boolean | `false` | Open cmux split panes for subagent sessions              |
+| Option                     | Type    | Default | Description                                              |
+|----------------------------|---------|---------|----------------------------------------------------------|
+| `splits`                   | boolean | `false` | Open cmux split panes for subagent sessions              |
+| `notifications.done`       | boolean | `true`  | Show a popup when a session finishes                     |
+| `notifications.permission` | boolean | `true`  | Show a popup when OpenCode requests a permission         |
+| `notifications.question`   | boolean | `true`  | Show a popup when OpenCode asks a clarifying question    |
+| `notifications.error`      | boolean | `true`  | Show a popup when a session errors                       |
 
-If the file does not exist, all options use their defaults.
+If the file does not exist or any key is omitted, defaults are used. Each notification type can be toggled independently — useful when running multiple agents in parallel and per-turn `Done` popups become noisy.
 
 ## Subagent splits
 
@@ -71,7 +78,7 @@ Without `--port`, splits are silently skipped even when enabled.
 
 ## How it works
 
-The plugin responds to OpenCode lifecycle events by firing cmux CLI commands (`cmux notify`, `cmux set-status`, etc.). Each action targets the current cmux workspace, providing ambient awareness of what OpenCode is doing without requiring you to switch context. All commands are no-ops when cmux is not running.
+The plugin responds to OpenCode lifecycle events by firing cmux CLI commands (`cmux rpc notification.create`, `cmux set-status`, etc.). Each action targets the current cmux workspace, providing ambient awareness of what OpenCode is doing without requiring you to switch context. All commands are no-ops when cmux is not running.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "build": "tsc --emitDeclarationOnly && bun build src/index.ts --outdir dist --target node",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "bun run typecheck && bun run build"
+    "test": "bun test",
+    "prepublishOnly": "bun run typecheck && bun run test && bun run build"
   },
   "keywords": [
     "opencode",

--- a/src/cmux.ts
+++ b/src/cmux.ts
@@ -16,16 +16,38 @@ export function isInCmux(): boolean {
   )
 }
 
+async function getPaneLabel($: Shell): Promise<string> {
+  const tmuxPane = process.env.TMUX_PANE
+  if (!tmuxPane) return ""
+  try {
+    const result =
+      await $`tmux display-message -p -t ${tmuxPane} -F '#{session_name}:#{window_index} #{pane_id}'`
+        .quiet()
+        .nothrow()
+    if (result.exitCode === 0) {
+      const text = result.stdout?.toString?.()?.trim?.()
+      if (text) return `[${text}]`
+    }
+  } catch {}
+  return `[${tmuxPane}]`
+}
+
 export async function notify(
   $: Shell,
   opts: { title: string; subtitle?: string; body?: string },
 ): Promise<void> {
   if (!isInCmux()) return
   try {
+    const prefix = await getPaneLabel($)
     const bodyParts: string[] = []
     if (opts.subtitle !== undefined) bodyParts.push(opts.subtitle)
     if (opts.body !== undefined) bodyParts.push(opts.body)
-    const body = bodyParts.join(" — ")
+    const baseBody = bodyParts.join(" — ")
+    const body = prefix
+      ? baseBody
+        ? `${prefix} ${baseBody}`
+        : prefix
+      : baseBody
     const payload = JSON.stringify({ title: opts.title, body })
     await $`${CMUX} rpc notification.create ${payload}`.quiet().nothrow()
   } catch {

--- a/src/cmux.ts
+++ b/src/cmux.ts
@@ -3,6 +3,12 @@ import type { PluginInput } from "@opencode-ai/plugin"
 
 type Shell = PluginInput["$"]
 
+const CMUX = ((): string => {
+  const fromEnv = process.env.CMUX_BUNDLED_CLI_PATH
+  if (fromEnv && existsSync(fromEnv)) return fromEnv
+  return "cmux"
+})()
+
 export function isInCmux(): boolean {
   return (
     existsSync(process.env.CMUX_SOCKET_PATH ?? "/tmp/cmux.sock") ||
@@ -16,10 +22,12 @@ export async function notify(
 ): Promise<void> {
   if (!isInCmux()) return
   try {
-    const args: string[] = ["--title", opts.title]
-    if (opts.subtitle !== undefined) args.push("--subtitle", opts.subtitle)
-    if (opts.body !== undefined) args.push("--body", opts.body)
-    await $`cmux notify ${args}`.quiet().nothrow()
+    const bodyParts: string[] = []
+    if (opts.subtitle !== undefined) bodyParts.push(opts.subtitle)
+    if (opts.body !== undefined) bodyParts.push(opts.body)
+    const body = bodyParts.join(" — ")
+    const payload = JSON.stringify({ title: opts.title, body })
+    await $`${CMUX} rpc notification.create ${payload}`.quiet().nothrow()
   } catch {
     // swallow errors silently
   }
@@ -36,7 +44,7 @@ export async function setStatus(
     const args: string[] = [key, text]
     if (opts?.icon !== undefined) args.push("--icon", opts.icon)
     if (opts?.color !== undefined) args.push("--color", opts.color)
-    await $`cmux set-status ${args}`.quiet().nothrow()
+    await $`${CMUX} set-status ${args}`.quiet().nothrow()
   } catch {
     // swallow errors silently
   }
@@ -45,7 +53,7 @@ export async function setStatus(
 export async function clearStatus($: Shell, key: string): Promise<void> {
   if (!isInCmux()) return
   try {
-    await $`cmux clear-status ${key}`.quiet().nothrow()
+    await $`${CMUX} clear-status ${key}`.quiet().nothrow()
   } catch {
     // swallow errors silently
   }
@@ -66,7 +74,7 @@ export async function log(
     }
     if (opts?.source !== undefined) args.push("--source", opts.source)
     args.push("--", message)
-    await $`cmux log ${args}`.quiet().nothrow()
+    await $`${CMUX} log ${args}`.quiet().nothrow()
   } catch {
     // swallow errors silently
   }
@@ -88,7 +96,7 @@ export async function createSplit(
   try {
     const args: string[] = [direction]
     if (fromSurface) args.push("--surface", fromSurface)
-    const result = await $`cmux new-split ${args}`.quiet().nothrow()
+    const result = await $`${CMUX} new-split ${args}`.quiet().nothrow()
     const text = result.text().trim()
     if (!text) return null
     // Output format: "OK surface:<n> workspace:<n>"
@@ -105,7 +113,7 @@ export async function focusSurface(
 ): Promise<void> {
   if (!isInCmux()) return
   try {
-    await $`cmux focus-surface --surface ${surfaceId}`.quiet().nothrow()
+    await $`${CMUX} focus-surface --surface ${surfaceId}`.quiet().nothrow()
   } catch {
     // swallow errors silently
   }
@@ -119,7 +127,7 @@ export async function sendToSurface(
   if (!isInCmux()) return
   try {
     const args = ["--surface", surfaceId, text]
-    await $`cmux send ${args}`.quiet().nothrow()
+    await $`${CMUX} send ${args}`.quiet().nothrow()
   } catch {
     // swallow errors silently
   }
@@ -132,7 +140,7 @@ export async function sendKeyToSurface(
 ): Promise<void> {
   if (!isInCmux()) return
   try {
-    await $`cmux send-key --surface ${surfaceId} ${key}`.quiet().nothrow()
+    await $`${CMUX} send-key --surface ${surfaceId} ${key}`.quiet().nothrow()
   } catch {
     // swallow errors silently
   }
@@ -144,7 +152,7 @@ export async function closeSurface(
 ): Promise<void> {
   if (!isInCmux()) return
   try {
-    await $`cmux close-surface --surface ${surfaceId}`.quiet().nothrow()
+    await $`${CMUX} close-surface --surface ${surfaceId}`.quiet().nothrow()
   } catch {
     // swallow errors silently
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,12 +23,45 @@ const plugin: Plugin = async ({ client, $ }) => {
 
   // Read plugin config (once at init)
   let splitsEnabled = false
+  const notifyOn: { done: boolean; permission: boolean; question: boolean; error: boolean } = {
+    done: true,
+    permission: true,
+    question: true,
+    error: true,
+  }
   try {
     const configPath = `${homedir()}/.config/opencode/opencode-cmux.json`
     const raw = readFileSync(configPath, "utf-8")
     const config = JSON.parse(raw)
     if (config.splits === true) {
       splitsEnabled = true
+    }
+    if (config.notifications !== undefined) {
+      if (
+        typeof config.notifications === "object" &&
+        config.notifications !== null &&
+        !Array.isArray(config.notifications)
+      ) {
+        const n = config.notifications as Record<string, unknown>
+        for (const key of ["done", "permission", "question", "error"] as const) {
+          const v = n[key]
+          if (v === undefined) continue
+          if (v === false) notifyOn[key] = false
+          else if (v === true) notifyOn[key] = true
+          else {
+            console.warn(
+              `[opencode-cmux] config.notifications.${key} ignored: expected boolean, got ${typeof v}`,
+            )
+          }
+        }
+      } else {
+        const got = Array.isArray(config.notifications)
+          ? "array"
+          : typeof config.notifications
+        console.warn(
+          `[opencode-cmux] config.notifications ignored: expected object, got ${got}`,
+        )
+      }
     }
   } catch {
     // File missing, unreadable, or invalid JSON — use defaults
@@ -233,7 +266,7 @@ const plugin: Plugin = async ({ client, $ }) => {
           const title = session?.title ?? sessionID
 
           if (!session?.parentID) {
-            await notify($, { title: `Done: ${title}` })
+            if (notifyOn.done) await notify($, { title: `Done: ${title}` })
             await log($, `Done: ${title}`, { level: "success", source: "opencode" })
             await clearStatus($, "opencode")
           } else {
@@ -257,7 +290,7 @@ const plugin: Plugin = async ({ client, $ }) => {
           ? (await fetchSession(sessionID))?.title ?? sessionID
           : "unknown session"
 
-        await notify($, { title: `Error: ${title}` })
+        if (notifyOn.error) await notify($, { title: `Error: ${title}` })
         await log($, `Error in session: ${title}`, {
           level: "error",
           source: "opencode",
@@ -277,7 +310,8 @@ const plugin: Plugin = async ({ client, $ }) => {
             icon: "lock",
             color: "#ef4444",
           })
-          await notify($, { title: "Needs your permission", subtitle: title })
+          if (notifyOn.permission)
+            await notify($, { title: "Needs your permission", subtitle: title })
           await log($, `Permission requested: ${title}`, {
             level: "info",
             source: "opencode",
@@ -312,7 +346,8 @@ const plugin: Plugin = async ({ client, $ }) => {
           icon: "help-circle",
           color: "#a855f7",
         })
-        await notify($, { title: "Has a question", subtitle: header })
+        if (notifyOn.question)
+          await notify($, { title: "Has a question", subtitle: header })
         await log($, `Question: ${header}`, { level: "info", source: "opencode" })
         return
       }
@@ -344,7 +379,8 @@ const plugin: Plugin = async ({ client, $ }) => {
         icon: "lock",
         color: "#ef4444",
       })
-      await notify($, { title: "Needs your permission", subtitle: title })
+      if (notifyOn.permission)
+        await notify($, { title: "Needs your permission", subtitle: title })
       await log($, `Permission requested: ${title}`, {
         level: "info",
         source: "opencode",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import type { Plugin } from "@opencode-ai/plugin"
 import { execSync } from "node:child_process"
 import { readFileSync } from "node:fs"
 import { homedir } from "node:os"
+import { join } from "node:path"
 import {
   notify,
   setStatus,
@@ -14,6 +15,8 @@ import {
   sendKeyToSurface,
   type SplitDirection,
 } from "./cmux.js"
+
+export const LSOF_LISTEN_RE = /:(\d+)\s+\(LISTEN\)/
 
 const plugin: Plugin = async ({ client, $ }) => {
   const pendingPermissions = new Set<string>()
@@ -30,7 +33,10 @@ const plugin: Plugin = async ({ client, $ }) => {
     error: true,
   }
   try {
-    const configPath = `${homedir()}/.config/opencode/opencode-cmux.json`
+    // Respect XDG_CONFIG_HOME, fall back to ~/.config per the XDG Base
+    // Directory Specification (https://specifications.freedesktop.org/basedir-spec/).
+    const configDir = process.env.XDG_CONFIG_HOME || join(homedir(), ".config")
+    const configPath = join(configDir, "opencode", "opencode-cmux.json")
     const raw = readFileSync(configPath, "utf-8")
     const config = JSON.parse(raw)
     if (config.splits === true) {
@@ -101,7 +107,7 @@ const plugin: Plugin = async ({ client, $ }) => {
         { encoding: "utf-8", timeout: 3000 },
       )
       for (const line of out.split("\n")) {
-        const match = line.match(/:(\d+)\s+\(LISTEN\)/)
+        const match = line.match(LSOF_LISTEN_RE)
         if (match) {
           discoveredServerUrl = `http://localhost:${match[1]}`
           return discoveredServerUrl

--- a/test/lsof-parse.test.ts
+++ b/test/lsof-parse.test.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "bun:test"
+import { LSOF_LISTEN_RE } from "../src/index"
+
+test("LSOF_LISTEN_RE captures the port from a real lsof line", () => {
+  const line =
+    "node    12345 kevin   23u  IPv4 0x12345      0t0  TCP *:38421 (LISTEN)"
+  expect(line.match(LSOF_LISTEN_RE)?.[1]).toBe("38421")
+})
+
+test("LSOF_LISTEN_RE matches localhost and IPv6 forms", () => {
+  expect("TCP localhost:4096 (LISTEN)".match(LSOF_LISTEN_RE)?.[1]).toBe("4096")
+  expect("TCP [::1]:8080 (LISTEN)".match(LSOF_LISTEN_RE)?.[1]).toBe("8080")
+})
+
+test("LSOF_LISTEN_RE does not match non-LISTEN lines", () => {
+  expect("TCP *:38421 (ESTABLISHED)".match(LSOF_LISTEN_RE)).toBeNull()
+  expect("TCP *:38421".match(LSOF_LISTEN_RE)).toBeNull()
+})
+
+// Catches the class of bug from PR #11 review: a one-shot edit injected
+// U+200B (zero-width space) into the regex source, silently breaking the
+// match. Asserting the source is pure ASCII traps any future invisible-
+// character regression at the test layer instead of in production.
+test("LSOF_LISTEN_RE source contains only printable ASCII", () => {
+  expect(LSOF_LISTEN_RE.source).toMatch(/^[\x20-\x7E]+$/)
+})


### PR DESCRIPTION
## Summary

Three paired fixes for users running OpenCode over SSH+tmux into a remote with cmux on macOS. Notifications were silently dropping on the floor; this PR makes them fire reliably and self-identify the source pane, plus adds opt-in/out per event type.

Verified on cmux 0.63.2, OpenCode 1.14.25, bun 1.3.11. No new dependencies. No public API changes.

## What's included

### Modified files
- `src/cmux.ts` — `CMUX` resolver via `CMUX_BUNDLED_CLI_PATH`, `getPaneLabel()` helper, rewrote `notify()` to call `cmux rpc notification.create` with a JSON payload, swapped all other subcommands to the resolved binary
- `src/index.ts` — config loader now parses a `notifications` block, four event handlers (`done`, `permission`, `question`, `error`) gate on the per-event flag before calling `notify()`
- `README.md` — documents the new config keys; updates stale references to `/usr/local/bin/cmux` and `cmux notify`

## Bugs discovered and fixed

**Commit `728ea56` — bundled CLI path + RPC form:**

1. **Bare `cmux` not on PATH under SSH+tmux.** cmux installs to `~/.cmux/bin/`, which isn't on `$PATH` in non-interactive shells, so bun's `$` template fails with `command not found: cmux`. `.nothrow()` swallows it and nothing fires. Fix: resolve the binary via `CMUX_BUNDLED_CLI_PATH` (exported by cmux's `relay/<port>.bootstrap.sh`), with `existsSync()` check and fallback to bare `cmux` when the env var is missing or stale.

2. **`cmux notify` CLI doesn't fire popups on 0.63.2.** Per cmux's `daemon/remote/cmd/cmuxd-remote/cli.go`, the `notify` subcommand only accepts `--title`, `--body`, `--workspace` — `--subtitle` is rejected as an unknown flag. Empirically even valid `--title --body` returns surface metadata without firing a Mac popup. Fix: call the v2 RPC method directly via `cmux rpc notification.create '{\"title\":...,\"body\":...}'`, per cmux's `docs/v2-api-migration.md`.

**Commit `4ca7f36` — pane self-identification:**

3. **One `surface_id` per SSH session.** All tmux panes inside a single SSH session share cmux's surface attribution, so popups get labeled with whatever pane cmux thinks is \"current,\" not the firing pane. Can't fix on cmux's side. Mitigation: prepend `[<session>:<window> <pane_id>]` from `tmux display-message` to the body when `TMUX_PANE` is set. Falls back to raw `[$TMUX_PANE]` if the subprocess fails, no prefix outside tmux.

**Commit `eabcb8a` — per-event config:**

4. **All-or-nothing notifications are noisy when running multiple agents.** Added a `notifications: { done, permission, question, error }` block in `~/.config/opencode/opencode-cmux.json`. All keys default to `true` (existing behavior preserved). Malformed shapes (arrays, non-boolean values) are dropped with a single `console.warn` at init.

## Safety / compatibility

- Non-tmux users: no behavioral change (pane prefix is gated on `TMUX_PANE`).
- Users without `CMUX_BUNDLED_CLI_PATH`: falls through to bare `cmux` (existing behavior).
- Users on older cmux without v2 RPC: `nothrow()` keeps failures silent, same as before.
- Default config matches old behavior; opting in is explicit.

## How to test

~~~bash
bun run typecheck
bun run build

# End-to-end: trigger each event in an OpenCode session inside cmux+tmux
#   done       — finish a turn
#   permission — request a tool permission
#   question   — agent asks for input
#   error      — induce a session error
# Confirm: macOS popup fires, body starts with [session:window %paneN]
~~~

## Verified against cmux source

- `daemon/remote/cmd/cmuxd-remote/cli.go` — flag whitelist for `notify`
- `docs/v2-api-migration.md` — v1→v2 method mapping
- `web/app/[locale]/docs/api/page.tsx` — public RPC usage example
- `relay/<port>.bootstrap.sh` — `CMUX_BUNDLED_CLI_PATH` export