### PR TITLE
fix(loader): keep plugin entrypoint function-only

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { execSync } from "node:child_process"
 import { readFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
+import { LSOF_LISTEN_RE } from "./lsof.js"
 import {
   notify,
   setStatus,
@@ -15,8 +16,6 @@ import {
   sendKeyToSurface,
   type SplitDirection,
 } from "./cmux.js"
-
-export const LSOF_LISTEN_RE = /:(\d+)\s+\(LISTEN\)/
 
 const plugin: Plugin = async ({ client, $ }) => {
   const pendingPermissions = new Set<string>()

--- a/src/lsof.ts
+++ b/src/lsof.ts
@@ -1,0 +1,1 @@
+export const LSOF_LISTEN_RE = /:(\d+)\s+\(LISTEN\)/

--- a/test/lsof-parse.test.ts
+++ b/test/lsof-parse.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test"
-import { LSOF_LISTEN_RE } from "../src/index"
+import { LSOF_LISTEN_RE } from "../src/lsof"
 
 test("LSOF_LISTEN_RE captures the port from a real lsof line", () => {
   const line =

--- a/test/plugin-export.test.ts
+++ b/test/plugin-export.test.ts
@@ -1,15 +1,27 @@
 import { test, expect } from "bun:test"
+import { existsSync } from "node:fs"
+import { execFileSync } from "node:child_process"
 import plugin from "../src/index"
 import * as pluginModule from "../src/index"
-import builtPlugin from "../dist/index.js"
-import * as builtPluginModule from "../dist/index.js"
+
+async function loadBuiltPluginModule() {
+  const builtPluginPath = new URL("../dist/index.js", import.meta.url)
+
+  if (!existsSync(builtPluginPath)) {
+    execFileSync("bun", ["run", "build"], { stdio: "inherit" })
+  }
+
+  return import("../dist/index.js")
+}
 
 test("public plugin module only exposes a default function export", () => {
   expect(typeof plugin).toBe("function")
   expect(Object.keys(pluginModule)).toEqual(["default"])
 })
 
-test("built plugin module only exposes a default function export", () => {
-  expect(typeof builtPlugin).toBe("function")
+test("built plugin module only exposes a default function export", async () => {
+  const builtPluginModule = await loadBuiltPluginModule()
+
+  expect(typeof builtPluginModule.default).toBe("function")
   expect(Object.keys(builtPluginModule)).toEqual(["default"])
 })

--- a/test/plugin-export.test.ts
+++ b/test/plugin-export.test.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "bun:test"
+import plugin from "../src/index"
+import * as pluginModule from "../src/index"
+import builtPlugin from "../dist/index.js"
+import * as builtPluginModule from "../dist/index.js"
+
+test("public plugin module only exposes a default function export", () => {
+  expect(typeof plugin).toBe("function")
+  expect(Object.keys(pluginModule)).toEqual(["default"])
+})
+
+test("built plugin module only exposes a default function export", () => {
+  expect(typeof builtPlugin).toBe("function")
+  expect(Object.keys(builtPluginModule)).toEqual(["default"])
+})


### PR DESCRIPTION
Closes #12

This PR focuses on the compatibility fix. The original bug report and reproduction details are captured in #12.

## Summary

- remove the named runtime export from the public plugin entrypoint
- move `LSOF_LISTEN_RE` into an internal helper module used by runtime code and tests
- add regression coverage to ensure both source and built entrypoints only expose a default function export

## Changes

| File | Change |
|------|--------|
| `src/index.ts` | stop exposing the regex from the public plugin entrypoint |
| `src/lsof.ts` | add the internal regex helper module |
| `test/lsof-parse.test.ts` | import the regex from the internal helper |
| `test/plugin-export.test.ts` | add regression coverage for source and built export shape |

## Test Plan

- [x] `bun run typecheck`
- [x] `bun test`
- [x] `bun run build`

## Notes for Review

- the change is intentionally narrow and only adjusts the plugin entrypoint surface
- the goal is to preserve compatibility without changing plugin behavior
- issue #12 contains the full context for the loader regression and observed runtime error