### PR TITLE
cmux: suppress OK output from notify RPC calls

### DIFF
--- a/src/cmux.ts
+++ b/src/cmux.ts
@@ -49,7 +49,7 @@ export async function notify(
         : prefix
       : baseBody
     const payload = JSON.stringify({ title: opts.title, body })
-    await $`${CMUX} rpc notification.create ${payload}`.quiet().nothrow()
+    await $`${CMUX} rpc notification.create ${payload} >/dev/null 2>&1`.nothrow()
   } catch {
     // swallow errors silently
   }


### PR DESCRIPTION
The cmux CLI outputs 'OK' to stdout on success for notification.create. When opencode-cmux calls the CLI, this pollutes the user's terminal with visual noise.

This PR redirects stdout/stderr to /dev/null so notifications are silent.

**Fix:** Changed `.quiet().nothrow()` to `>/dev/null 2>&1`.nothrow()` in src/cmux.ts:52

Fixes visual noise in live terminal where opencode-cmux is active.